### PR TITLE
Add guild-specific settings to Megalog module

### DIFF
--- a/migrations/20210805195504_megalog_guild_settings/migration.sql
+++ b/migrations/20210805195504_megalog_guild_settings/migration.sql
@@ -1,0 +1,34 @@
+-- AlterTable
+ALTER TABLE "MegalogSettings" ADD COLUMN     "guildAttachCondensedJsonDefault" BOOLEAN,
+ADD COLUMN     "guildShowCondensedPreviewDefault" BOOLEAN;
+
+-- CreateTable
+CREATE TABLE "MegalogGuildSettings" (
+    "guildId" VARCHAR(20) NOT NULL,
+    "attachCondensedJson" BOOLEAN,
+    "showCondensedPreview" BOOLEAN,
+
+    PRIMARY KEY ("guildId")
+);
+
+CREATE CONSTRAINT TRIGGER "MegalogGuildSettings_insert_trigger"
+    AFTER INSERT
+    ON "MegalogGuildSettings"
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+EXECUTE FUNCTION trigger_notify_entity_insert_or_update();
+
+CREATE CONSTRAINT TRIGGER "MegalogGuildSettings_update_trigger"
+    AFTER UPDATE
+    ON "MegalogGuildSettings"
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+    WHEN (OLD <> NEW)
+EXECUTE FUNCTION trigger_notify_entity_insert_or_update();
+
+CREATE CONSTRAINT TRIGGER "MegalogGuildSettings_delete_trigger"
+    AFTER DELETE
+    ON "MegalogGuildSettings"
+    DEFERRABLE INITIALLY DEFERRED
+    FOR EACH ROW
+EXECUTE FUNCTION trigger_notify_entity_delete('guildId');

--- a/src/database/wrapper/SynchronizedEntityWrapper.ts
+++ b/src/database/wrapper/SynchronizedEntityWrapper.ts
@@ -53,7 +53,7 @@ export abstract class SynchronizedEntityWrapper<
       typeof arg1 === 'object'
         ? {
             ...this.defaultedEntity,
-            arg1,
+            ...arg1,
           }
         : produce(this.defaultedEntity, arg1)
     );

--- a/src/modules/megalog/MegalogModule.ts
+++ b/src/modules/megalog/MegalogModule.ts
@@ -16,6 +16,7 @@ import {messageEditEventType} from './eventTypes/message/messageEditEventType';
 import {MegalogChannelManager} from './MegalogChannelManager';
 import {getMegalogSettings} from './settings/getMegalogSettings';
 import {MegalogSettingsWrapper} from './settings/MegalogSettingsWrapper';
+import {MegalogGuildSettingsManager} from './guildSettings/MegalogGuildSettingsManager';
 
 /**
  * Module that logs nearly all Discord events to text channels.
@@ -47,6 +48,12 @@ export class MegalogModule extends Module {
     return this._auditLogMatcher;
   }
 
+  private _guildSettings!: MegalogGuildSettingsManager;
+
+  get guildSettings(): MegalogGuildSettingsManager {
+    return this._guildSettings;
+  }
+
   private readonly client: Client;
 
   private readonly globalSettings: GlobalSettingsWrapper;
@@ -57,13 +64,13 @@ export class MegalogModule extends Module {
     globalSettings = moduleContainer.resolve(GlobalSettingsWrapper)
   ) {
     super(moduleContainer);
+    this.client = client;
+    this.globalSettings = globalSettings;
 
     this.container.registerSingleton(MegalogEventTypeManager);
     this.container.registerSingleton(MegalogChannelManager);
     this.container.registerSingleton(AuditLogMatcher);
-
-    this.client = client;
-    this.globalSettings = globalSettings;
+    this.container.registerSingleton(MegalogGuildSettingsManager);
   }
 
   async preInitialize(): Promise<void> {
@@ -77,7 +84,9 @@ export class MegalogModule extends Module {
     this._eventTypeManager = this.container.resolve(MegalogEventTypeManager);
     this._auditLogMatcher = this.container.resolve(AuditLogMatcher);
     this._channelManager = this.container.resolve(MegalogChannelManager);
+    this._guildSettings = this.container.resolve(MegalogGuildSettingsManager);
     await this._channelManager.initialize();
+    await this._guildSettings.initialize();
   }
 
   async initialize(): Promise<void> {

--- a/src/modules/megalog/MegalogModule.ts
+++ b/src/modules/megalog/MegalogModule.ts
@@ -91,9 +91,11 @@ export class MegalogModule extends Module {
 
   async initialize(): Promise<void> {
     this.eventTypeManager.registerEventType(attachmentSendEventType(this.globalSettings));
-    this.eventTypeManager.registerEventType(messageEditEventType(this.globalSettings));
     this.eventTypeManager.registerEventType(
-      messageDeleteSingleEventType(this.globalSettings, this.channelManager)
+      messageEditEventType(this.globalSettings, this.guildSettings)
+    );
+    this.eventTypeManager.registerEventType(
+      messageDeleteSingleEventType(this.globalSettings, this.channelManager, this.guildSettings)
     );
   }
 

--- a/src/modules/megalog/condensers/condenseMessage.ts
+++ b/src/modules/megalog/condensers/condenseMessage.ts
@@ -27,7 +27,7 @@ export function condenseMessage(
     author_id: message.author?.id,
     webhook_id: message.webhookID ?? undefined,
     timestamp: message.createdTimestamp,
-    edited_timestamp: message.editedTimestamp ?? undefined,
+    edited_timestamp: message.editedTimestamp || undefined,
     reactions:
       message.reactions.cache.size === 0
         ? undefined

--- a/src/modules/megalog/guildSettings/MegalogGuildSettingsManager.ts
+++ b/src/modules/megalog/guildSettings/MegalogGuildSettingsManager.ts
@@ -1,0 +1,60 @@
+import {CacheManager, CacheSynchronizer, DatabaseEventHub} from '@/database';
+import {resolveIdChecked} from '@/utils/resolve';
+import {MegalogGuildSettings, Prisma, PrismaClient} from '@prisma/client';
+import {GuildManager, GuildResolvable, Snowflake} from 'discord.js';
+import {injectable} from 'tsyringe';
+import {MegalogSettingsWrapper} from '../settings/MegalogSettingsWrapper';
+import {MegalogGuildSettingsWrapper} from './MegalogGuildSettingsWrapper';
+
+@injectable()
+export class MegalogGuildSettingsManager extends CacheManager<
+  PrismaClient['megalogGuildSettings'],
+  Snowflake,
+  MegalogGuildSettingsWrapper
+> {
+  private readonly synchronizer: CacheSynchronizer<MegalogGuildSettings, 'guildId', Snowflake>;
+
+  private readonly megalogSettings: MegalogSettingsWrapper;
+
+  private readonly guildManager: GuildManager;
+
+  constructor(
+    prisma: PrismaClient,
+    guildManager: GuildManager,
+    eventHub: DatabaseEventHub,
+    megalogSettings: MegalogSettingsWrapper
+  ) {
+    super(prisma.megalogGuildSettings);
+    this.megalogSettings = megalogSettings;
+    this.guildManager = guildManager;
+    this.synchronizer = new CacheSynchronizer(
+      eventHub,
+      Prisma.ModelName.MegalogGuildSettings,
+      ({guildId}) => guildId
+    );
+  }
+
+  async initialize(): Promise<void> {
+    await this.synchronizer.initialize();
+  }
+
+  async fetch(guild: GuildResolvable): Promise<MegalogGuildSettingsWrapper> {
+    const id = resolveIdChecked(this.guildManager, guild);
+
+    const cached = this.cache.get(id);
+    if (cached) return cached;
+
+    const syncStream = this.synchronizer.getSyncStream(id);
+    const entity = await this.model.findUnique({where: {guildId: id}});
+    const wrapper = new MegalogGuildSettingsWrapper(
+      this.megalogSettings,
+      this,
+      syncStream,
+      entity ?? undefined,
+      await this.guildManager.fetch(id)
+    );
+    wrapper.afterDecache.subscribe(() => this.synchronizer.removeSyncStream(id));
+    this.cacheWrapper(id, wrapper);
+    return wrapper;
+  }
+}

--- a/src/modules/megalog/guildSettings/MegalogGuildSettingsWrapper.ts
+++ b/src/modules/megalog/guildSettings/MegalogGuildSettingsWrapper.ts
@@ -1,0 +1,106 @@
+import {SynchronizedEntityWrapper, SyncStream} from '@/database';
+import {MegalogGuildSettings} from '@prisma/client';
+import {Guild} from 'discord.js';
+import {MegalogSettingsWrapper} from '../settings/MegalogSettingsWrapper';
+import type {MegalogGuildSettingsManager} from './MegalogGuildSettingsManager';
+
+/**
+ * Holds the current settings of the Megalog module for a specific guild.
+ */
+export class MegalogGuildSettingsWrapper extends SynchronizedEntityWrapper<
+  MegalogGuildSettings | undefined
+> {
+  readonly guild: Guild;
+
+  /**
+   * Whether a condensed json of the event should be attached to the log message.
+   *
+   * Setting it to `undefined` will make it use the default value again.
+   */
+  get attachCondensedJson(): boolean {
+    return this.rawAttachCondensedJson ?? this.megalogSettings.guildAttachCondensedJsonDefault;
+  }
+
+  set attachCondensedJson(value: boolean | undefined) {
+    this.rawAttachCondensedJson = value;
+  }
+
+  get rawAttachCondensedJson(): boolean | undefined {
+    return this.entity?.attachCondensedJson ?? undefined;
+  }
+
+  set rawAttachCondensedJson(value: boolean | undefined) {
+    // eslint-disable-next-line unicorn/no-null
+    this.updateEntity({attachCondensedJson: value ?? null});
+  }
+
+  /**
+   * Filename ending of the condensed json attachment depending on {@link MegalogGuildSettingsWrapper.showCondensedPreview}.
+   */
+  get condensedFileNameEnding(): string {
+    return this.showCondensedPreview ? '.json' : '-json';
+  }
+
+  /**
+   * Whether the attached condensed json should show with a preview directly in the end user Discord client.
+   *
+   * Setting it to `undefined` will make it use the default value again.
+   */
+  get showCondensedPreview(): boolean {
+    return this.rawShowCondensedPreview ?? this.megalogSettings.guildShowCondensedPreviewDefault;
+  }
+
+  set showCondensedPreview(value: boolean | undefined) {
+    this.rawShowCondensedPreview = value;
+  }
+
+  get rawShowCondensedPreview(): boolean | undefined {
+    return this.entity?.showCondensedPreview ?? undefined;
+  }
+
+  set rawShowCondensedPreview(value: boolean | undefined) {
+    // eslint-disable-next-line unicorn/no-null
+    this.updateEntity({showCondensedPreview: value ?? null});
+  }
+
+  private readonly megalogSettings: MegalogSettingsWrapper;
+
+  private readonly manager: MegalogGuildSettingsManager;
+
+  constructor(
+    megalogSettings: MegalogSettingsWrapper,
+    manager: MegalogGuildSettingsManager,
+    syncStream: SyncStream<MegalogGuildSettings>,
+    entity: MegalogGuildSettings | undefined,
+    guild: Guild
+  ) {
+    super(syncStream, entity);
+    this.megalogSettings = megalogSettings;
+    this.manager = manager;
+    this.guild = guild;
+  }
+
+  protected createDefaultEntity(): MegalogGuildSettings {
+    return {
+      guildId: this.guild.id,
+      // eslint-disable-next-line unicorn/no-null
+      attachCondensedJson: null,
+      // eslint-disable-next-line unicorn/no-null
+      showCondensedPreview: null,
+    };
+  }
+
+  async save(): Promise<void> {
+    if (this.rawAttachCondensedJson === undefined && this.rawShowCondensedPreview === undefined) {
+      await this.manager.model.delete({
+        where: {guildId: this.guild.id},
+      });
+      return;
+    }
+    await this.manager.model.upsert({
+      create: this.entity as MegalogGuildSettings,
+      update: this.entity as MegalogGuildSettings,
+      where: {guildId: this.guild.id},
+    });
+  }
+}

--- a/src/modules/megalog/schema.prisma
+++ b/src/modules/megalog/schema.prisma
@@ -7,9 +7,17 @@ model MegalogLogChannel {
 }
 
 model MegalogSettings {
-  version                     Int  @id @default(autoincrement())
-  auditLogMatchTryInterval    Int?
-  auditLogFetchSize           Int?
-  maxAuditLogMatchQueueLength Int?
-  maxAuditLogMatchTries       Int?
+  version                          Int      @id @default(autoincrement())
+  auditLogMatchTryInterval         Int?
+  auditLogFetchSize                Int?
+  maxAuditLogMatchQueueLength      Int?
+  maxAuditLogMatchTries            Int?
+  guildAttachCondensedJsonDefault  Boolean?
+  guildShowCondensedPreviewDefault Boolean?
+}
+
+model MegalogGuildSettings {
+  guildId              String   @id @db.VarChar(20)
+  attachCondensedJson  Boolean?
+  showCondensedPreview Boolean?
 }

--- a/src/modules/megalog/settings/MegalogSettingsWrapper.ts
+++ b/src/modules/megalog/settings/MegalogSettingsWrapper.ts
@@ -29,4 +29,12 @@ export class MegalogSettingsWrapper extends SettingsWrapper<MegalogSettings> {
   get maxAuditLogMatchTries(): number {
     return this.entity?.maxAuditLogMatchTries ?? 10;
   }
+
+  get guildAttachCondensedJsonDefault(): boolean {
+    return this.entity?.guildAttachCondensedJsonDefault ?? true;
+  }
+
+  get guildShowCondensedPreviewDefault(): boolean {
+    return this.entity?.guildShowCondensedPreviewDefault ?? false;
+  }
 }


### PR DESCRIPTION
Has following changes:
- Implements guild-specific settings for the Megalog module with the following settings:
  - Disable/enable condensed JSON attachments on log messages
  - Disable/enable direct preview of these JSON files in the Discord client
- Fixes an issue with `SynchronizedEntityWrapper.updateEntity`